### PR TITLE
Make package.json dev deps available in nix dev-shell.

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -23,7 +23,7 @@ let
       cp ${src}/package.json $out/package.json
       cp ${src}/package-lock.json $out/package-lock.json
       cd $out
-      node2nix --lock package-lock.json
+      node2nix --development --lock package-lock.json
     '')
     { inherit pkgs nodejs system; };
   nodeModules =


### PR DESCRIPTION
This is a solution proposed by @t1lde to address `npm run build` failures after entering nix dev-shell.